### PR TITLE
Google admob

### DIFF
--- a/app/src/main/java/com/ctu/planitstudy/feature/data/data_source/googleadomb/GoogleAdmob.kt
+++ b/app/src/main/java/com/ctu/planitstudy/feature/data/data_source/googleadomb/GoogleAdmob.kt
@@ -41,7 +41,6 @@ class GoogleAdmob {
                 }
 
                 override fun onAdLoaded(interstitialAd: InterstitialAd) {
-                    Log.d(TAG, "Ad was loaded.")
                     mInterstitialAd = interstitialAd
                     if (onAdLoadedFun != null) {
                         onAdLoadedFun()
@@ -58,21 +57,18 @@ class GoogleAdmob {
     ) {
         mInterstitialAd?.fullScreenContentCallback = object : FullScreenContentCallback() {
             override fun onAdDismissedFullScreenContent() {
-                Log.d(TAG, "Ad was dismissed.")
                 if (onAdDismissed != null) {
                     onAdDismissed()
                 }
             }
 
             override fun onAdFailedToShowFullScreenContent(adError: AdError?) {
-                Log.d(TAG, "Ad failed to show.")
                 if (onAdFailedShow != null) {
                     onAdFailedShow()
                 }
             }
 
             override fun onAdShowedFullScreenContent() {
-                Log.d(TAG, "Ad showed fullscreen content.")
                 if (onAdShowed != null) {
                     onAdShowed()
                 }
@@ -88,7 +84,6 @@ class GoogleAdmob {
         if (mInterstitialAd != null) {
             mInterstitialAd?.show(activity)
         } else {
-            Log.d("TAG", "The interstitial ad wasn't ready yet.")
             if (onFailedLoad != null)
                 onFailedLoad()
         }

--- a/app/src/main/java/com/ctu/planitstudy/feature/domain/use_case/reward/GetPlanetPassListUseCase.kt
+++ b/app/src/main/java/com/ctu/planitstudy/feature/domain/use_case/reward/GetPlanetPassListUseCase.kt
@@ -13,5 +13,7 @@ class GetPlanetPassListUseCase @Inject constructor(
 
     val TAG = "GetPlanetPassListUseCase - 로그"
 
+    suspend fun getRewardPlanet() = rewardRepository.getRewardPlanet()
+
     operator fun invoke(): Flow<Resource<PlanetListDto>> = useCase { rewardRepository.getRewardPlanet() }
 }

--- a/app/src/main/java/com/ctu/planitstudy/feature/presentation/CashStudyApp.kt
+++ b/app/src/main/java/com/ctu/planitstudy/feature/presentation/CashStudyApp.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import com.ctu.planitstudy.R
 import com.ctu.planitstudy.core.util.PreferencesManager
 import com.google.android.gms.ads.MobileAds
-import com.google.android.gms.ads.RequestConfiguration
 import com.kakao.sdk.common.KakaoSdk
 import com.microsoft.appcenter.AppCenter
 import com.microsoft.appcenter.analytics.Analytics

--- a/app/src/main/java/com/ctu/planitstudy/feature/presentation/home/fragment/rewards/RewardViewModel.kt
+++ b/app/src/main/java/com/ctu/planitstudy/feature/presentation/home/fragment/rewards/RewardViewModel.kt
@@ -1,6 +1,5 @@
 package com.ctu.planitstudy.feature.presentation.home.fragment.rewards
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope

--- a/app/src/main/java/com/ctu/planitstudy/feature/presentation/home/fragment/rewards/RewardViewModel.kt
+++ b/app/src/main/java/com/ctu/planitstudy/feature/presentation/home/fragment/rewards/RewardViewModel.kt
@@ -1,5 +1,6 @@
 package com.ctu.planitstudy.feature.presentation.home.fragment.rewards
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
@@ -34,13 +35,10 @@ class RewardViewModel @Inject constructor(
             when (it) {
                 is Resource.Success -> {
                     _rewardDto.value = it.data!!
-                    loadingDismiss()
                 }
                 is Resource.Error -> {
-                    loadingErrorDismiss()
                 }
                 is Resource.Loading -> {
-                    loadingShow()
                 }
             }
         }.launchIn(viewModelScope)

--- a/app/src/main/java/com/ctu/planitstudy/feature/presentation/home/fragment/rewards/RewardsFragment.kt
+++ b/app/src/main/java/com/ctu/planitstudy/feature/presentation/home/fragment/rewards/RewardsFragment.kt
@@ -21,9 +21,10 @@ import com.ctu.planitstudy.feature.presentation.dialogs.ReadyDialog
 import com.ctu.planitstudy.feature.presentation.dialogs.SingleTitleCheckDialog
 import com.ctu.planitstudy.feature.presentation.util.Screens
 import dagger.hilt.android.AndroidEntryPoint
-import io.reactivex.Completable
-import io.reactivex.Observable
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class RewardsFragment : BaseFragment<FragmentRewardsBinding, RewardViewModel>() {
@@ -49,7 +50,6 @@ class RewardsFragment : BaseFragment<FragmentRewardsBinding, RewardViewModel>() 
         super.setInit()
         viewModel.getReward()
         googleLoad()
-
 
         with(binding) {
             activity = this@RewardsFragment

--- a/app/src/main/java/com/ctu/planitstudy/feature/presentation/planitpass/PlanitPassScreen.kt
+++ b/app/src/main/java/com/ctu/planitstudy/feature/presentation/planitpass/PlanitPassScreen.kt
@@ -16,15 +16,11 @@ import com.ctu.planitstudy.feature.presentation.dialogs.ReadyDialog
 import com.ctu.planitstudy.feature.presentation.dialogs.SingleTitleCheckDialog
 import com.ctu.planitstudy.feature.presentation.sign_up.view_pager.PlanitFragmentStateAdapter
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.*
 import java.lang.Math.abs
-import kotlin.coroutines.CoroutineContext
 
 @AndroidEntryPoint
 class PlanitPassScreen :
-    BaseBindingActivity<ActivityPlanitPassScreenBinding, PlanitPassViewModel>(),
-    CoroutineScope
-{
+    BaseBindingActivity<ActivityPlanitPassScreenBinding, PlanitPassViewModel>() {
 
     override val bindingInflater: (LayoutInflater) -> ActivityPlanitPassScreenBinding
         get() = ActivityPlanitPassScreenBinding::inflate
@@ -37,15 +33,9 @@ class PlanitPassScreen :
 
     private val googleAdmob = GoogleAdmob()
 
-
-    lateinit var job: Job
-    override val coroutineContext: CoroutineContext
-        get() = Dispatchers.Main + job
-
     val TAG = "PlanitPassScreen - 로그"
 
     override fun setup() {
-        job = Job()
         binding.activity = this
         binding.viewmodel = viewModel
         viewModel.rewardDto = intent.getParcelableExtra<RewardDto>("reward") ?: RewardDto(0, 0, 0)
@@ -90,7 +80,6 @@ class PlanitPassScreen :
         )
 
         googleLoad()
-
     }
 
     fun nextPass() {
@@ -138,7 +127,6 @@ class PlanitPassScreen :
                     onAdDismissed = {
                         googleLoad()
                         convertPoint()
-
                     }
                 )
             },
@@ -183,11 +171,6 @@ class PlanitPassScreen :
             return true
         }
         return super.onKeyDown(keyCode, event)
-    }
-
-    override fun onDestroy() {
-        job.cancel()
-        super.onDestroy()
     }
 
     fun showReadyDialog() {

--- a/app/src/main/java/com/ctu/planitstudy/feature/presentation/planitpass/PlanitPassViewModel.kt
+++ b/app/src/main/java/com/ctu/planitstudy/feature/presentation/planitpass/PlanitPassViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.ctu.core.util.Resource
 import com.ctu.planitstudy.core.base.BaseViewModel
+import com.ctu.planitstudy.feature.data.remote.dto.reward.PlanetListDto
 import com.ctu.planitstudy.feature.data.remote.dto.reward.RewardDto
 import com.ctu.planitstudy.feature.domain.use_case.reward.RewardUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -26,8 +27,20 @@ class PlanitPassViewModel @Inject constructor(
     private val _newPoint = MutableLiveData<Int>()
     val newPoint: LiveData<Int> = _newPoint
 
+//    suspend fun getPlanetPass() = rewardUseCase.getPlanetPassListUseCase.getRewardPlanet()
+
     init {
         getPlanetPass()
+    }
+
+    fun setUpPlanetPass(planetListDto: PlanetListDto) {
+        val newPlanetList = mutableListOf<PlanetPass>()
+        planetListDto.planets.let { plaent ->
+            for (n in plaent)
+                newPlanetList.add(PlanetPass(n.planetId, n.name, n.description))
+        }
+
+        _planetPassList.value = PlanetPassList(newPlanetList)
     }
 
     private fun getPlanetPass() {
@@ -41,17 +54,15 @@ class PlanitPassViewModel @Inject constructor(
                     }
 
                     _planetPassList.value = PlanetPassList(newPlanetList)
-                    loadingDismiss()
                 }
                 is Resource.Error -> {
-                    loadingErrorDismiss()
                 }
                 is Resource.Loading -> {
-                    loadingShow()
                 }
             }
         }.launchIn(viewModelScope)
     }
+
     fun convertPassToPoint(pass: Int) {
         rewardUseCase.convertPlanitPassToPointUseCase(pass).onEach {
             when (it) {


### PR DESCRIPTION
- 이전에는 리워드 정보, 플래닛 패스 리스트만 가져오면 로딩이 끝났다 하지만 광고 호출시간이 상당히 길기 때문에 광고호출 시간이 끝날때 까지 로딩바가 지속 되도록 수정하여 광고없는 상황에서 상호작용할 수 없도록 수정